### PR TITLE
fix: add missing package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
   "main": "index.js",
   "types": "index.d.ts",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "types": "./index.d.ts",
-      "import": "./index.js"
+      "default": "./index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
package.json should be exported to support certain tools:
https://github.com/ianprime0509/pitchy/pull/108

The `default` export condition should be preferred to just using
`import`, also to support certain tools:
https://github.com/ianprime0509/pitchy/pull/112