### PR TITLE
ci: decrease Dependabot frequency to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     commit-message:
       prefix: "build(deps):"
       prefix-development: "build(dev):"


### PR DESCRIPTION
There is only one non-development dependency in this repository, and it is not frequently updated.